### PR TITLE
Improved CLI parsing and added support for extra Typst arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ This requires that you're using Typst locally -- it won't work with the web app.
 
    The resulting images are saved in the `.typst_pyimage` folder.
 
+   For more information on the available arguments, run `python -m typst_pyimage -h`.
+
 ## Notes
 
 It's common to have an initial block of code that is in common to all `#pyimage("...")` and `#pycontent("...")` calls (such as import statements, defining helpers etc). These can be placed in a `#pyinit("...")` directive.

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ This requires that you're using Typst locally -- it won't work with the web app.
 3. Compile or watch. Run either of the following two commands:
 
    ```
-   python -m typst_pyimage --compile your_file.typ
-   python -m typst_pyimage --watch your_file.typ
+   python -m typst_pyimage compile your_file.typ
+   python -m typst_pyimage watch your_file.typ
    ```
 
    This will extract and run all your Python code. In addition it will call either `typst compile your_file.typ` or `typst watch your_file.typ`.

--- a/README.md
+++ b/README.md
@@ -61,20 +61,22 @@ This requires that you're using Typst locally -- it won't work with the web app.
 
 2. Use these functions.
 
-    a. `pyimage(string, ..arguments) -> content`. The positional string should be a Python program that creates a single matplotlib figure. Any named arguments are forwarded on to Typst's built-in `image` function. You can use it just like the normal `image` function, e.g. `#align(center, pyimage("..."))`.
+   a. `pyimage(string, ..arguments) -> content`. The positional string should be a Python program that creates a single matplotlib figure. Any named arguments are forwarded on to Typst's built-in `image` function. You can use it just like the normal `image` function, e.g. `#align(center, pyimage("..."))`.
 
-    b. `pycontent(string)`. The positional string should be a Python program that produces a string on its final line. This string will be treated as Typst code.
+   b. `pycontent(string)`. The positional string should be a Python program that produces a string on its final line. This string will be treated as Typst code.
 
-    c. `pyinit(string)`. The positional string should be a Python program. This will be evaluated before all `pyimage` or `pycontent` calls, e.g. to perform imports or other setup.
+   c. `pyinit(string)`. The positional string should be a Python program. This will be evaluated before all `pyimage` or `pycontent` calls, e.g. to perform imports or other setup.
 
 3. Compile or watch. Run either of the following two commands:
-    ```
-    python -m typst_pyimage compile your_file.typ
-    python -m typst_pyimage watch your_file.typ
-    ```
-    This will extract and run all your Python code. In addition it will call either `typst compile your_file.typ` or `typst watch your_file.typ`.
 
-    The resulting images are saved in the `.typst_pyimage` folder.
+   ```
+   python -m typst_pyimage --compile your_file.typ
+   python -m typst_pyimage --watch your_file.typ
+   ```
+
+   This will extract and run all your Python code. In addition it will call either `typst compile your_file.typ` or `typst watch your_file.typ`.
+
+   The resulting images are saved in the `.typst_pyimage` folder.
 
 ## Notes
 
@@ -83,6 +85,7 @@ It's common to have an initial block of code that is in common to all `#pyimage(
 Each `#pyimage("...")` block is executed as a fresh module (i.e. as if each was a separate Python file), but with the same Python interpreter.
 
 Overall, this is essentially equivalent to the following Python code:
+
 ```
 # main.py
 import pyinit
@@ -100,6 +103,7 @@ from pyinit import *
 from pyinit import *
 ...  # your second #pyimage("...") code
 ```
+
 This means that e.g. any global caches will be shared across all `#pyimage("...")` calls. (Useful when using a library like JAX, which has a JIT compilation cache.)
 
 ## Limitations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typst_pyimage"
-version = "0.0.3"
+version = "0.1.0"
 description = "Typst extension, adding support for generating figures using inline Python code"
 readme = "README.md"
 requires-python = "~=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typst_pyimage"
-version = "0.1.0"
+version = "0.0.4"
 description = "Typst extension, adding support for generating figures using inline Python code"
 readme = "README.md"
 requires-python = "~=3.8"

--- a/typst_pyimage/__main__.py
+++ b/typst_pyimage/__main__.py
@@ -7,7 +7,7 @@ from .run import watch as watch
 # Create the parser
 parser = argparse.ArgumentParser(
     prog="typst_pyimage",
-    description="Typst extension, adding support for generating figures using inline Python code",
+    description="Typst extension, adding support for generating figures using inline Python code.",
 )
 
 # Required positional argument

--- a/typst_pyimage/__main__.py
+++ b/typst_pyimage/__main__.py
@@ -1,8 +1,7 @@
 import argparse
 import os
 
-from .run import compile as compile
-from .run import watch as watch
+from .run import compile as compile, watch as watch
 
 
 def parse_args(args):
@@ -37,18 +36,28 @@ def _watch_wrapper(args):
     watch(filepath, extra_args)
 
 
+program_description = (
+    "Typst extension, adding support for generating"
+    + " figures using inline Python code."
+)
+
+
 # Create the parser
 parser = argparse.ArgumentParser(
     prog="typst_pyimage",
-    description="Typst extension, adding support for generating figures using inline Python code.",
+    description=program_description,
 )
 
 # Create subparsers
 subparser = parser.add_subparsers(help="sub-command help")
 
 # Create subparsers for the subcommands
-subparser_compile = subparser.add_parser("compile", aliases=["c"], help="Compile the typst file")
-subparser_watch = subparser.add_parser("watch", aliases=["w"], help="Watch the typst file")
+subparser_compile = subparser.add_parser(
+    "compile", aliases=["c"], help="Compile the typst file"
+)
+subparser_watch = subparser.add_parser(
+    "watch", aliases=["w"], help="Watch the typst file"
+)
 
 # Set the subparsers to call the appropriate function
 subparser_compile.set_defaults(func=_compile_wrapper)

--- a/typst_pyimage/__main__.py
+++ b/typst_pyimage/__main__.py
@@ -1,14 +1,46 @@
-import sys
+import argparse
+import os
 
-from .run import compile as compile, watch as watch
+from .run import compile as compile
+from .run import watch as watch
 
+# Create the parser
+parser = argparse.ArgumentParser(
+    prog="typst_pyimage",
+    description="Typst extension, adding support for generating figures using inline Python code",
+)
 
-if len(sys.argv) != 3:
-    raise RuntimeError("Usage is `python -m typst_pyimage <command> <file>`")
-_, command, filename = sys.argv
-if command == "watch":
-    watch(filename)
-elif command == "compile":
-    compile(filename)
-else:
-    raise RuntimeError(f"Invalid command {command}")
+# Required positional argument
+parser.add_argument(
+    "filepath",
+    action="store",
+    type=str,
+    help="The path to the typst file to be compiled/watched",
+)
+
+# Boolean flags
+# The user can only choose one of these flags at a time
+group = parser.add_mutually_exclusive_group()
+group.add_argument("-c", "--compile", action="store_false", help="Compile the typst file")
+group.add_argument("-w", "--watch", action="store_false", help="Watch the typst file")
+
+# Optional argument
+parser.add_argument(
+    "-a",
+    "--extra-args",
+    type=str,
+    help="Extra arguments to be passed to typst",
+)
+
+# Parse the arguments
+args = parser.parse_args()
+
+filepath = args.filepath
+do_compile = args.compile
+do_watch = args.watch
+extra_args = args.extra_args.replace("~", os.path.expanduser("~")).split()
+
+if do_compile:
+    watch(filepath, extra_args)
+elif do_watch:
+    compile(filepath, extra_args)

--- a/typst_pyimage/run.py
+++ b/typst_pyimage/run.py
@@ -151,7 +151,7 @@ def _initial(
     return filepath, dirpath, init_code, init_scope
 
 
-def watch(filename: Union[str, pathlib.Path], timeout_s: Optional[int] = None):
+def watch(filename: Union[str, pathlib.Path], extra_args: list[str] = [], timeout_s: Optional[int] = None):
     figcache = {}
     contentcache = {}
     filepath, dirpath, init_code, init_scope = _initial(filename, contentcache, figcache)
@@ -160,7 +160,7 @@ def watch(filename: Union[str, pathlib.Path], timeout_s: Optional[int] = None):
     file_time = last_time = _get_file_time(filepath)
     keep_running = True
     need_update = False
-    process = subprocess.Popen(["typst", "watch", str(filepath)])
+    process = subprocess.Popen(["typst", "watch"] + extra_args + [str(filepath)])
     try:
         while keep_running:
             if need_update:
@@ -177,6 +177,6 @@ def watch(filename: Union[str, pathlib.Path], timeout_s: Optional[int] = None):
         process.kill()
 
 
-def compile(filename: Union[str, pathlib.Path]):
+def compile(filename: Union[str, pathlib.Path], extra_args: list[str] = []):
     filepath, _, _, _ = _initial(filename, figcache=None, contentcache=None)
-    subprocess.run(["typst", "compile", str(filepath)])
+    subprocess.run(["typst", "compile"] + extra_args + [str(filepath)])

--- a/typst_pyimage/run.py
+++ b/typst_pyimage/run.py
@@ -151,7 +151,9 @@ def _initial(
     return filepath, dirpath, init_code, init_scope
 
 
-def watch(filename: Union[str, pathlib.Path], extra_args: list[str] = [], timeout_s: Optional[int] = None):
+def watch(filename: Union[str, pathlib.Path], extra_args: Optional[list[str]] = None, timeout_s: Optional[int] = None):
+    if extra_args is None:
+        extra_args = []
     figcache = {}
     contentcache = {}
     filepath, dirpath, init_code, init_scope = _initial(filename, contentcache, figcache)
@@ -177,6 +179,8 @@ def watch(filename: Union[str, pathlib.Path], extra_args: list[str] = [], timeou
         process.kill()
 
 
-def compile(filename: Union[str, pathlib.Path], extra_args: list[str] = []):
+def compile(filename: Union[str, pathlib.Path], extra_args: Optional[list[str]] = None):
+    if extra_args is None:
+        extra_args = []
     filepath, _, _, _ = _initial(filename, figcache=None, contentcache=None)
     subprocess.run(["typst", "compile"] + extra_args + [str(filepath)])

--- a/typst_pyimage/run.py
+++ b/typst_pyimage/run.py
@@ -9,6 +9,7 @@ from typing import Optional, Tuple, Union
 import matplotlib
 import matplotlib.pyplot as plt
 
+
 pyinit_re = re.compile(r"pyinit\(\s*\"([^\"]*)\"")
 pyimage_re = re.compile(r"pyimage\(\s*\"([^\"]*)\"")
 pycontent_re = re.compile(r"pycontent\(\s*\"([^\"]*)\"")
@@ -147,16 +148,24 @@ def _initial(
     dirpath = filepath.parent / ".typst_pyimage"
     dirpath.mkdir(exist_ok=True)
     shutil.copy(installpath / "pyimage.typ", dirpath / "pyimage.typ")
-    init_code, init_scope = _make_images(filepath, dirpath, figcache, contentcache, "", {})
+    init_code, init_scope = _make_images(
+        filepath, dirpath, figcache, contentcache, "", {}
+    )
     return filepath, dirpath, init_code, init_scope
 
 
-def watch(filename: Union[str, pathlib.Path], extra_args: Optional[list[str]] = None, timeout_s: Optional[int] = None):
+def watch(
+    filename: Union[str, pathlib.Path],
+    extra_args: Optional[list[str]] = None,
+    timeout_s: Optional[int] = None,
+):
     if extra_args is None:
         extra_args = []
     figcache = {}
     contentcache = {}
-    filepath, dirpath, init_code, init_scope = _initial(filename, contentcache, figcache)
+    filepath, dirpath, init_code, init_scope = _initial(
+        filename, contentcache, figcache
+    )
     del filename
     start_time = time.time()
     file_time = last_time = _get_file_time(filepath)
@@ -167,7 +176,9 @@ def watch(filename: Union[str, pathlib.Path], extra_args: Optional[list[str]] = 
         while keep_running:
             if need_update:
                 last_time = file_time
-                init_code, init_scope = _make_images(filepath, dirpath, figcache, contentcache, init_code, init_scope)
+                init_code, init_scope = _make_images(
+                    filepath, dirpath, figcache, contentcache, init_code, init_scope
+                )
             time.sleep(0.1)
             file_time = _get_file_time(filepath)
             need_update = file_time > last_time

--- a/typst_pyimage/run.py
+++ b/typst_pyimage/run.py
@@ -9,7 +9,6 @@ from typing import Optional, Tuple, Union
 import matplotlib
 import matplotlib.pyplot as plt
 
-
 pyinit_re = re.compile(r"pyinit\(\s*\"([^\"]*)\"")
 pyimage_re = re.compile(r"pyimage\(\s*\"([^\"]*)\"")
 pycontent_re = re.compile(r"pycontent\(\s*\"([^\"]*)\"")
@@ -148,18 +147,14 @@ def _initial(
     dirpath = filepath.parent / ".typst_pyimage"
     dirpath.mkdir(exist_ok=True)
     shutil.copy(installpath / "pyimage.typ", dirpath / "pyimage.typ")
-    init_code, init_scope = _make_images(
-        filepath, dirpath, figcache, contentcache, "", {}
-    )
+    init_code, init_scope = _make_images(filepath, dirpath, figcache, contentcache, "", {})
     return filepath, dirpath, init_code, init_scope
 
 
 def watch(filename: Union[str, pathlib.Path], timeout_s: Optional[int] = None):
     figcache = {}
     contentcache = {}
-    filepath, dirpath, init_code, init_scope = _initial(
-        filename, contentcache, figcache
-    )
+    filepath, dirpath, init_code, init_scope = _initial(filename, contentcache, figcache)
     del filename
     start_time = time.time()
     file_time = last_time = _get_file_time(filepath)
@@ -170,9 +165,7 @@ def watch(filename: Union[str, pathlib.Path], timeout_s: Optional[int] = None):
         while keep_running:
             if need_update:
                 last_time = file_time
-                init_code, init_scope = _make_images(
-                    filepath, dirpath, figcache, contentcache, init_code, init_scope
-                )
+                init_code, init_scope = _make_images(filepath, dirpath, figcache, contentcache, init_code, init_scope)
             time.sleep(0.1)
             file_time = _get_file_time(filepath)
             need_update = file_time > last_time


### PR DESCRIPTION
# Context

I use a typst template which is stored somewhere on my computer. I therefore need to update the typst root with the `--root` argument when I compile or watch a typst file. I needed a way to pass extra arguments to typst through the python package.

# Solution

I updated/improved the parsing of the CLI arguments.
- The parsing is now done with the `argparse` python package
	- This enables a more robust and complex parsing if needed
	- The CLI now features a help menu
	- The CLI is now arguably more easily maintainable
- There is added support for extra arguments that are passed to the typst compiler

> Changes were tested locally on my side and everything works properly.

# Changes

The way to execute commands was changed a bit. The README has been updated accordingly. Here is the new CLI:
```
> python -m typst_pyimage -h

usage: typst_pyimage [-h] [-c | -w] [-a EXTRA_ARGS] filepath

Typst extension, adding support for generating figures using inline Python code.

positional arguments:
  filepath              The path to the typst file to be compiled/watched

options:
  -h, --help            show this help message and exit
  -c, --compile         Compile the typst file
  -w, --watch           Watch the typst file
  -a EXTRA_ARGS, --extra-args EXTRA_ARGS
                        Extra arguments to be passed to typst
```

